### PR TITLE
Fix output of treelib

### DIFF
--- a/ssm_tree/main.py
+++ b/ssm_tree/main.py
@@ -77,4 +77,4 @@ def build_tree(path, recursive, show_encrypted=False):
     if not tree:
         print("Nothing to show.")
     else:
-        return tree.show()
+        print(tree.show(stdout=False))


### PR DESCRIPTION
- At least on Python 3, instead of a nicely formatted tree the former command showed a byte string (b'...').
- See also https://github.com/caesar0301/treelib/issues/221